### PR TITLE
Fix deprecation warnings in Swift 4.0

### DIFF
--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -50,12 +50,12 @@ open class FaveButton: UIButton {
         static let dotRadiusFactors     = (first: 0.0633, second: 0.04)
     }
     
-    @IBInspectable open var normalColor: UIColor     = UIColor(colorLiteralRed: 137/255, green: 156/255, blue: 167/255, alpha: 1)
-    @IBInspectable open var selectedColor: UIColor   = UIColor(colorLiteralRed: 226/255, green: 38/255,  blue: 77/255,  alpha: 1)
-    @IBInspectable open var dotFirstColor: UIColor   = UIColor(colorLiteralRed: 152/255, green: 219/255, blue: 236/255, alpha: 1)
-    @IBInspectable open var dotSecondColor: UIColor  = UIColor(colorLiteralRed: 247/255, green: 188/255, blue: 48/255,  alpha: 1)
-    @IBInspectable open var circleFromColor: UIColor = UIColor(colorLiteralRed: 221/255, green: 70/255,  blue: 136/255, alpha: 1)
-    @IBInspectable open var circleToColor: UIColor   = UIColor(colorLiteralRed: 205/255, green: 143/255, blue: 246/255, alpha: 1)
+    @IBInspectable open var normalColor: UIColor     = UIColor(red: 137.0/255.0, green: 156.0/255.0, blue: 167.0/255.0, alpha: 1)
+    @IBInspectable open var selectedColor: UIColor   = UIColor(red: 226.0/255.0, green: 38.0/255.0,  blue: 77.0/255.0,  alpha: 1)
+    @IBInspectable open var dotFirstColor: UIColor   = UIColor(red: 152.0/255.0, green: 219.0/255.0, blue: 236.0/255.0, alpha: 1)
+    @IBInspectable open var dotSecondColor: UIColor  = UIColor(red: 247.0/255.0, green: 188.0/255.0, blue: 48.0/255.0,  alpha: 1)
+    @IBInspectable open var circleFromColor: UIColor = UIColor(red: 221.0/255.0, green: 70.0/255.0,  blue: 136.0/255.0, alpha: 1)
+    @IBInspectable open var circleToColor: UIColor   = UIColor(red: 205.0/255.0, green: 143.0/255.0, blue: 246.0/255.0, alpha: 1)
     
     @IBOutlet open weak var delegate: AnyObject?
     


### PR DESCRIPTION
- Replace usage of *UIColor* constructor `init(colorLiteralRed:green:blue:alpha:)` with `init(red:green:blue:alpha:)`
- Replace parameter values with explicit float literals to avoid integer truncation